### PR TITLE
Corrected radius expression

### DIFF
--- a/coordinates/sat.py
+++ b/coordinates/sat.py
@@ -214,7 +214,7 @@ def gps_sat_xyz(ephemeris, sec):
     u0k = tettak + w0
     uk = u0k + cuc * cos(2 * u0k) + cus * sin(2 * u0k)
 
-    rk = a0 * (1 + e0 * cos(ek)) + crc * cos(2 * u0k) + crs * sin(2 * u0k)
+    rk = a0 * (1 - e0 * cos(ek)) + crc * cos(2 * u0k) + crs * sin(2 * u0k)
 
     ik = i0 + (cic * cos(2 * u0k) + cis * sin(2 * u0k)) + i_dot * tk
 


### PR DESCRIPTION
There was a mistake in the satellite orbit radius expression:
`rk = a0 * (1 + e0 * cos(ek)) + crc * cos(2 * u0k) + crs * sin(2 * u0k)`
it was replaced by:
`rk = a0 * (1 - e0 * cos(ek)) + crc * cos(2 * u0k) + crs * sin(2 * u0k)`
check r_k expression in [here](https://ascelibrary.org/doi/pdf/10.1061/9780784411506.ap03)